### PR TITLE
docs(readme): add standard status badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Release](https://img.shields.io/github/v/release/fjacquet/netstack?sort=semver)](https://github.com/fjacquet/netstack/releases/latest)
+
 <p align="center">
   <img src="public/android-chrome-192x192.png" alt="NetStack logo" width="96" height="96">
 </p>


### PR DESCRIPTION
Adds the standard README badge set (CI + latest release + license where applicable) to match the rest of the fleet. Docs-only.