### PR TITLE
ci: adopt central web-release.yml@v1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,8 @@ on:
     tags: ['v*']
 permissions:
   contents: write
+  id-token: write       # OIDC for build-provenance attestation
+  attestations: write   # write the provenance attestation
 jobs:
   release:
     uses: fjacquet/ci/.github/workflows/web-release.yml@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,55 +1,15 @@
-name: Release with Offline Package
-
+name: Release
 on:
   push:
     tags: ['v*']
-
 permissions:
   contents: write
-  id-token: write  # required for SBOM attestation
-
 jobs:
   release:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: lts/*
-          cache: 'npm'
-
-      - run: npm ci
-
-      - run: npm run typecheck
-
-      - run: npm test
-
-      # Build portable offline package (base: ./ for local file:// usage)
-      - name: Build offline package
-        run: npm run build
-        env:
-          NETSTACK_BASE: './'
-
-      - name: Create offline archives
-        run: |
-          VERSION="${GITHUB_REF_NAME}"
-          cd dist
-          zip -r "../netstack-${VERSION}-offline.zip" .
-          cd ..
-          tar -czf "netstack-${VERSION}-offline.tar.gz" -C dist .
-
-      - name: Generate SBOM
-        uses: anchore/sbom-action@v0
-        with:
-          format: cyclonedx-json
-          output-file: sbom.cyclonedx.json
-
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          generate_release_notes: true
-          files: |
-            netstack-*-offline.zip
-            netstack-*-offline.tar.gz
-            sbom.cyclonedx.json
+    uses: fjacquet/ci/.github/workflows/web-release.yml@v1
+    with:
+      node-version: "24"
+      publish-npm: false
+      publish-docker: false
+      build-dir: "dist"
+      archive-name: "netstack"


### PR DESCRIPTION
Adopt the central reusable release workflow `fjacquet/ci/.github/workflows/web-release.yml@v1`, replacing the bespoke release pipeline.

## ⚠️ BREAKING: offline package archives dropped
The previous workflow built a portable **offline** package with `NETSTACK_BASE='./'` and published `netstack-*-offline.zip` / `netstack-*-offline.tar.gz`. **These offline archives are no longer produced.** The central workflow emits standard `dist` archives instead. Anyone relying on the offline (local `file://`) package must adjust.

## Retained
- **SBOM**: the CycloneDX SBOM is still generated — now provided centrally by `web-release`.
- **Archive base name**: `netstack` preserved via the `archive-name` input.

## Config
- `node-version: 24`
- `publish-npm: false`, `publish-docker: false`
- `build-dir: dist`

actionlint passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Release workflow refactored to leverage a centralized reusable CI/CD pipeline, streamlining the release process while maintaining automated releases on tag creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->